### PR TITLE
add bytestrings, rename define-core to define, support top-interaction

### DIFF
--- a/example/core-simple.rkt
+++ b/example/core-simple.rkt
@@ -1,33 +1,42 @@
 #lang rutus/core
 
-(define-core + (@ intro-builtin 'AddInteger))
-(define-core * (@ intro-builtin 'MultiplyInteger))
-(define-core - (@ intro-builtin 'SubtractInteger))
-
-(define-core (if condition t f)
+(define (if condition t f)
   (@ intro-force (core ((@ intro-builtin 'IfThenElse) condition (@ intro-delay t) (@ intro-delay f)))))
 
-(define-core < (@ intro-builtin 'LessThanInteger))
+(define < (@ intro-builtin 'LessThanInteger))
 
-(define-core (square x) (* x x))
+(define + (@ intro-builtin 'AddInteger))
+(define - (@ intro-builtin 'SubtractInteger))
+(define * (@ intro-builtin 'MultiplyInteger))
 
-(define-core (fix f) ((lambda (x) (f (lambda (v) ((x x) v)))) (lambda (x) (f (lambda (v) ((x x) v))))))
+(define (square x) (* x x))
 
-(define-core (iterate-n n f x)
+(define (fix f) ((lambda (x) (f (lambda (v) ((x x) v))))
+                      (lambda (x) (f (lambda (v) ((x x) v))))))
+
+(define (iterate-n n f x)
   ((fix (lambda (self n f x)
            (if (< n 1)
                x
                (self (- n 1) f (f x)))))
    n f x))
 
-(define-core iterate-n2
+(define iterate-n2
   (fix (lambda (self n f x)
-               (if (< n 1)
+               (if (< 1 n)
                    x
                    (self (- n 1) f (f x))))))
 
+(define foo "hi")
+
+(define bytestring-length (@ intro-builtin 'LengthOfByteString))
+
 (define-script
-   example
+  string-example
+  (bytestring-length foo))
+
+(define-script
+  example
   (iterate-n 5 square 2))
 
 (define-script

--- a/rutus/lib/coreterm.rkt
+++ b/rutus/lib/coreterm.rkt
@@ -17,6 +17,7 @@
          intro-app
          intro-let
          intro-integer
+         intro-bytestring
          intro-builtin
          intro-force
          intro-delay
@@ -46,7 +47,7 @@
            [(rt:app b [rt:var 0]) b]
            [(rt:abs n (rt:app t~ args))
             #:when
-            (and (displayln (map (match-lambda [(rt:var v) v] [_ #f]) args))
+            (and #;(displayln (map (match-lambda [(rt:var v) v] [_ #f]) args))
                  (eq? (map (match-lambda [(rt:var v) v] [_ #f]) args)
                       (range 0 (+ n 1))))
             t~]
@@ -112,7 +113,11 @@
 
 (define/contract (intro-integer n)
   (-> exact-integer? coreterm?)
-  (coreterm (λ (i) (rt:constant (plutus:constant-integer n)))))
+  (coreterm (λ (_) (rt:constant (plutus:constant-integer n)))))
+
+(define/contract (intro-bytestring s)
+  (-> string? coreterm?)
+  (coreterm (λ (_) (rt:constant (plutus:constant-bytestring (string->bytes/locale s))))))
 
 (define (intro-builtin builtin)
   (-> exact-integer? coreterm?)


### PR DESCRIPTION
Strings are now compiled to plutus bytestrings. This is implemented with `string->bytes/locale`, which is probably not ideal, but it works fine.

`define` is preferable to `define-core' because it exhibits less syntactic noise.

`#%top-interaction` now behaves as expected and interacting with core in the repl is much more pleasant.